### PR TITLE
Fix `assert_same_dtype`

### DIFF
--- a/zhusuan/distributions/utils.py
+++ b/zhusuan/distributions/utils.py
@@ -108,7 +108,7 @@ def assert_same_dtype(tensors_with_name, dtype=None):
 
     expected_dtype = dtype
     for tensor, tensor_name in tensors_with_name:
-        tensor_dtype = tensor.dtype
+        tensor_dtype = tensor.dtype.base_dtype
         if not expected_dtype:
             expected_dtype = tensor_dtype
         elif expected_dtype != tensor_dtype:
@@ -117,7 +117,7 @@ def assert_same_dtype(tensors_with_name, dtype=None):
                 raise TypeError(
                     '%s(%s), must be the same type as %s(%s).' % (
                         tensor_name, tensor_dtype,
-                        tensor0_name, tensor0.dtype))
+                        tensor0_name, tensor0.dtype.base_dtype))
             else:
                 raise TypeError(
                     '%s(%s), must be %s.' % (


### PR DESCRIPTION
In tf there are derived dtypes for reference-based tensors. I.e. `Variable().dtype == tf.int32_ref != tf.int32`. `zs.distributions.utils.assert_same_dtype` is invoked whenever a distribution with multiple parameters is constructed, but it did not consider this case. Thus the following code would fail:

```
a = tf.Variable(..., dtype=tf.float32) # dtype=tf.float32_ref
b = <some float32 op>
dist = zs.MultivariateNormalTriL(.., mean=a, cov_tril=b)  # Invoked assert_same_dtype(mean, cov_tril)
```

The solution is to use [`DType.base_dtype`](https://www.tensorflow.org/api_docs/python/tf/DType#base_dtype). 