### PR TITLE
tweak "_check_names_exist" and its callers in BayesianNet

### DIFF
--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -141,6 +141,11 @@ class TestBayesianNet(tf.test.TestCase):
         self.assertTrue(b_out is b.tensor)
         self.assertTrue(c_out is c.tensor)
 
+        # outputs by iterator
+        b_out_2, c_out_2 = model.outputs(iter(['b', 'c']))
+        self.assertIs(b_out_2, b_out)
+        self.assertIs(c_out_2, c_out)
+
         # local_log_prob
         log_pa = model.local_log_prob('a')
         log_pa_t = a.log_prob(a_observed)
@@ -154,6 +159,14 @@ class TestBayesianNet(tf.test.TestCase):
             log_pc_out, log_pc_t_out = sess.run([log_pc, log_pc_t])
             self.assertNear(log_pb_out, log_pb_t_out, 1e-6)
             self.assertNear(log_pc_out, log_pc_t_out, 1e-6)
+
+        # local_log_prob by iterator
+        log_pb_2, log_pc_2 = model.local_log_prob(iter(['b', 'c']))
+        with self.test_session(use_gpu=True) as sess:
+            log_pb_2_out, log_pb_t_out = sess.run([log_pb_2, log_pb_t])
+            log_pc_2_out, log_pc_t_out = sess.run([log_pc_2, log_pc_t])
+            self.assertNear(log_pb_2_out, log_pb_t_out, 1e-6)
+            self.assertNear(log_pc_2_out, log_pc_t_out, 1e-6)
 
         # query
         a_out, log_pa = model.query('a', outputs=True, local_log_prob=True)
@@ -171,6 +184,17 @@ class TestBayesianNet(tf.test.TestCase):
             self.assertNear(log_pa_out, log_pa_t_out, 1e-6)
             self.assertNear(log_pb_out, log_pb_t_out, 1e-6)
             self.assertNear(log_pc_out, log_pc_t_out, 1e-6)
+
+        # query by iterator
+        (b_out_2, log_pb_2), (c_out_2, log_pc_2) = \
+            model.query(iter(['b', 'c']), outputs=True, local_log_prob=True)
+        self.assertIs(b_out_2, b_out)
+        self.assertIs(c_out_2, c_out)
+        with self.test_session(use_gpu=True) as sess:
+            log_pb_2_out, log_pb_t_out = sess.run([log_pb_2, log_pb_t])
+            log_pc_2_out, log_pc_t_out = sess.run([log_pc_2, log_pc_t])
+            self.assertNear(log_pb_2_out, log_pb_t_out, 1e-6)
+            self.assertNear(log_pc_2_out, log_pc_t_out, 1e-6)
 
 
 class TestReuse(tf.test.TestCase):

--- a/zhusuan/model/base.py
+++ b/zhusuan/model/base.py
@@ -283,15 +283,18 @@ class BayesianNet(Context):
 
         :param name_or_names: A string or a list of strings. Names of
             `StochasticTensor` s in the network.
+        :return: The validated name, or a tuple of the validated names.
         """
-        if isinstance(name_or_names, (tuple, list)):
-            names = name_or_names
+        if isinstance(name_or_names, six.string_types):
+            names = (name_or_names,)
         else:
-            names = [name_or_names]
+            name_or_names = tuple(name_or_names)
+            names = name_or_names
         for name in names:
             if name not in self._stochastic_tensors:
                 raise ValueError("There is no StochasticTensor named '{}' in "
                                  "the BayesianNet.".format(name))
+        return name_or_names
 
     def get(self, name_or_names):
         """
@@ -300,8 +303,8 @@ class BayesianNet(Context):
         :param name_or_names: A string or a list of strings. Names of
             `StochasticTensor` s in the network.
         """
-        self._check_names_exist(name_or_names)
-        if isinstance(name_or_names, (tuple, list)):
+        name_or_names = self._check_names_exist(name_or_names)
+        if isinstance(name_or_names, tuple):
             return [self._stochastic_tensors[name] for name in name_or_names]
         else:
             return self._stochastic_tensors[name_or_names]
@@ -317,8 +320,8 @@ class BayesianNet(Context):
             `StochasticTensor` s in the network.
         :return: A Tensor or a list of Tensors.
         """
-        self._check_names_exist(name_or_names)
-        if isinstance(name_or_names, (tuple, list)):
+        name_or_names = self._check_names_exist(name_or_names)
+        if isinstance(name_or_names, tuple):
             return [self._stochastic_tensors[name].tensor
                     for name in name_or_names]
         else:
@@ -335,8 +338,8 @@ class BayesianNet(Context):
             `StochasticTensor` s in the network.
         :return: A Tensor or a list of Tensors.
         """
-        self._check_names_exist(name_or_names)
-        if isinstance(name_or_names, (tuple, list)):
+        name_or_names = self._check_names_exist(name_or_names)
+        if isinstance(name_or_names, tuple):
             ret = []
             for name in name_or_names:
                 s_tensor = self._stochastic_tensors[name]
@@ -366,7 +369,7 @@ class BayesianNet(Context):
 
         :return: Tuple of Tensors or a list of tuples of Tensors.
         """
-        self._check_names_exist(name_or_names)
+        name_or_names = self._check_names_exist(name_or_names)
         ret = []
         if outputs:
             ret.append(self.outputs(name_or_names))
@@ -374,7 +377,7 @@ class BayesianNet(Context):
             ret.append(self.local_log_prob(name_or_names))
         if len(ret) == 0:
             raise ValueError("No query options are selected.")
-        elif isinstance(name_or_names, (tuple, list)):
+        elif isinstance(name_or_names, tuple):
             return list(zip(*ret))
         else:
             return tuple(ret)


### PR DESCRIPTION
It is very, very unreliable to test `name_or_names` by ``isinstance(name_or_names, (tuple, list))``.  And what's worse, you would iterate over the original `name_or_names` for more than once.

A major problem is that if you pass an iterator as `name_or_names`, it will not be handled correctly.  For example:

> bn.get(some_dict.keys()) 
> bn.get(k for k in some_dict.keys() if k != 'something')
> bn.get(filter(lambda s: s != 'something', names))

Another thing to notice that for an iterator, you must first turn it into a list, then iterate it.  Otherwise it will be exhausted in the first iteration (i.e., your `_check_names_exist`).

So a better way to do this is to check it by ``isinstance(name_or_names, six.string_types)``, deal with the string case first, and then use the `else` clause to turn it into a fixed type (where I choose to use `tuple`).